### PR TITLE
Add .values property

### DIFF
--- a/bluedot/dot.py
+++ b/bluedot/dot.py
@@ -198,6 +198,14 @@ class BlueDot():
         Returns a 1 if the Blue Dot is pressed, 0 if released.
         """
         return 1 if self.is_pressed else 0
+    
+    @property
+    def values(self):
+        """
+        Returns an infinite generator constantly yielding the current value
+        """
+        while True:
+            yield self.value
 
     @property
     def dot_position(self):


### PR DESCRIPTION
In gpiozero, the `.values` property is an infinite generator constantly yielding the current value: https://gist.github.com/bennuttall/6f0c6b254b5718e6f8f582cec1ef7ed5

e.g.

```python
from gpiozero import LED
from bluedot import BlueDot
from signal import pause

led = LED(17)
bd = BlueDot()

led.source = bd.values

pause()
```

which is equivalent to:

```python
while True:
    if bd.is_pressed:
        led.on()
    else:
        led.off()
```

(I won't be offended if you don't accept this)