### PR TITLE
Fix app crash if device has no bluetooth support

### DIFF
--- a/clients/android/app/src/main/java/com/stuffaboutcode/bluedot/Devices.java
+++ b/clients/android/app/src/main/java/com/stuffaboutcode/bluedot/Devices.java
@@ -42,7 +42,8 @@ public class Devices extends AppCompatActivity {
             Toast.makeText(getApplicationContext(), "Bluetooth Device Not Available", Toast.LENGTH_LONG).show();
 
             //finish apk
-            finish();
+            this.finish();
+            System.exit(0);
 
         } else if(!myBluetooth.isEnabled()) {
             //Ask to the user turn the bluetooth on


### PR DESCRIPTION
finish() does not exit app, it just closes the Activity. Therefore
app will continue and crash at pairedDevicesList().