### PR TITLE
Pip install in user mode in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Getting Started
 
 1. Install the Python library::
 
-       sudo pip3 install bluedot
+       pip3 install bluedot --user
 
 2. Get the `Android Blue Dot app`_ or use the `Python Blue Dot app`_
 


### PR DESCRIPTION
It's not a good idea to encourage users to use sudo with Pip as it'll mess with their OS-managed site-packages content.