### PR TITLE
Fix small error on "visible" property doc

### DIFF
--- a/bluedot/dot.py
+++ b/bluedot/dot.py
@@ -986,7 +986,7 @@ class BlueDot(object):
     @property
     def visible(self):
         """
-        When set to `True` makes the dot invisible. Default is `False`.
+        When set to `False` makes the dot invisible. Default is `True`.
 
         .. note::
 


### PR DESCRIPTION
According to the constructor of BlueDot, visible is set to `True` by default.